### PR TITLE
お題の表示位置の変更・スクロール量の削減のためのUI調整を行いました

### DIFF
--- a/src/pages/ImageUpload.tsx
+++ b/src/pages/ImageUpload.tsx
@@ -1,8 +1,8 @@
 import { useState, useEffect } from "react";
 import Image from "next/image";
-import soraki from '../assets/samples/IMG_8278.jpg'
-import tabe from '../assets/samples/IMG_8279.jpg'
-import ise from '../assets/samples/IMG_8281.jpg'
+// import soraki from '../assets/samples/IMG_8278.jpg'
+// import tabe from '../assets/samples/IMG_8279.jpg'
+// import ise from '../assets/samples/IMG_8281.jpg'
 import WebCamera from "./Camera";
 
 type entries = {
@@ -73,18 +73,6 @@ export default function ImageUpload({ setSceneController, entries, setEntries}: 
 
   return(
     <>
-    <p className="mt-4">お題：「{thema}」</p>
-    <p className="mt-4">「{thema}」にちなんだ写真を撮ってください．</p>
-
-    <button type="button" onClick={ThemaChange} className="my-4 p-4 text-white font-bold bg-green-400 rounded-xl shadow-lg mx-2">お題を変更する</button>
-
-    <div
-    style={{
-      borderTop: "4px dotted gray", // 点線のスタイル
-      marginTop: "16px",            // 上の要素との間隔
-      width: "100%",                // 横幅を画面全体に
-    }}
-    ></div>
 
     <ol
     style={{
@@ -99,16 +87,13 @@ export default function ImageUpload({ setSceneController, entries, setEntries}: 
     className="mt-4"
     >
       <ul><span className="font-bold">お題にちなんだポーズ</span>で<span className="text-amber-300 text-2xl font-bold">{entries?.[indexId].name}</span>さんの写真を<span className="text-amber-300 text-2xl font-bold">{indexId === 0 ? entries?.[entries.length - 1].name : entries?.[indexId - 1].name}</span>さんが撮影してね！</ul>
-      <ul>{getRequiredPhotos(entries)}枚以上撮ってください</ul>
+      {/* <ul>{getRequiredPhotos(entries)}枚以上撮ってください</ul> */}
       <ul>全員分の写真が集まったらゲームスタート！</ul>
-      <p className="mt-4">ポーズの例</p>
+      {/* <p className="mt-4">ポーズの例</p> */}
       <div
       className="flex flex-wrap justify-center md:flex-col md:items-start"
       style={{ gap: "10px" }}
       >
-        <Image src={soraki} alt={"soraki"} width={110} />
-        <Image src={tabe} alt={"tabe"} width={110} />
-        <Image src={ise} alt={"ise"} width={110} />
       </div>
     </ol>
 
@@ -120,7 +105,17 @@ export default function ImageUpload({ setSceneController, entries, setEntries}: 
       }}
     ></div>
 
+    <p className="mt-4">お題：「{thema}」　にちなんだ写真を撮ってください．</p>
 
+    <button type="button" onClick={ThemaChange} className="my-4 p-4 text-white font-bold bg-green-400 rounded-xl shadow-lg mx-2">お題を変更する</button>
+
+    <div
+      style={{
+        borderTop: "4px dotted gray", // 点線のスタイル
+        marginTop: "16px",            // 上の要素との間隔
+        width: "100%",                // 横幅を画面全体に
+      }}
+    ></div>
 
     <WebCamera entries={entries} setEntries={setEntries} indexId={indexId} setThema={setThema} setIndexId_thema={setIndexId_thema}></WebCamera>
 
@@ -171,14 +166,6 @@ export default function ImageUpload({ setSceneController, entries, setEntries}: 
       }}
     ></div>
 
-    {indexId < entries?.length - 1 &&
-    <button
-      onClick={nextPlayer}
-      className="p-4 text-white font-bold bg-blue-400 rounded-xl shadow-lg m-2"
-    >
-      次のプレイヤーの写真を登録
-    </button>}
-
     <div className="flex justify-center gap-4 mt-4">
     <button
       onClick={() => setSceneController('Name')}
@@ -186,6 +173,14 @@ export default function ImageUpload({ setSceneController, entries, setEntries}: 
     >
       {entries?.[indexId].imgURL.length >= 0 && "プレイヤー登録に戻る"}
     </button>
+
+    {indexId < entries?.length - 1 &&
+    <button
+      onClick={nextPlayer}
+      className="p-4 text-white font-bold bg-blue-400 rounded-xl shadow-lg m-2"
+    >
+      次のプレイヤーの写真を登録
+    </button>}
 
     {indexId === entries?.length - 1 && entries?.[indexId].imgURL.length >= 2 && (
       <button


### PR DESCRIPTION
・やったこと
画像アップロード画面において，お題の表示位置の変更・スクロール量の削減のためのUI調整

・変更前
<img width="558" alt="スクリーンショット 2025-03-14 14 04 38" src="https://github.com/user-attachments/assets/78c01bb2-8fab-4ed6-9977-a9f623702b10" />
<img width="548" alt="スクリーンショット 2025-03-14 14 04 50" src="https://github.com/user-attachments/assets/aa0b7845-a938-485a-a571-8d79be023260" />

・変更後
<img width="540" alt="スクリーンショット 2025-03-14 14 05 58" src="https://github.com/user-attachments/assets/42670835-533f-416e-bc20-3d017a462679" />
