### PR TITLE
「Next」ボタンの説明文の位置を調整した

### DIFF
--- a/src/pages/Game.tsx
+++ b/src/pages/Game.tsx
@@ -76,7 +76,6 @@ export default function Game({ setSceneController, entries }: { setSceneControll
         />
         <p className="text-4xl text-amber-300 font-bold">{randomEntry.name}</p>
       </div>
-      <CountdownTimer timeLeft={timeLeft} setTimeLeft={setTimeLeft} isRunning={isRunning} ></CountdownTimer>
 
       {/* カウントダウン中には表示しない */}
       {/* 初めて表示された画像の場合 */}
@@ -114,6 +113,10 @@ export default function Game({ setSceneController, entries }: { setSceneControll
         Next
       </button>
       </div>
+
+      <br></br>
+
+      <CountdownTimer timeLeft={timeLeft} setTimeLeft={setTimeLeft} isRunning={isRunning} ></CountdownTimer>
     </div>
     </>
   )


### PR DESCRIPTION
・やったこと
ゲーム画面において，「Next」ボタンの説明文の位置を調整した

・変更前
<img width="355" alt="スクリーンショット 2025-03-14 15 17 47" src="https://github.com/user-attachments/assets/0bb1850d-fcb8-4537-b533-b0ae34be1403" />

・変更後
<img width="307" alt="スクリーンショット 2025-03-14 15 14 55" src="https://github.com/user-attachments/assets/d99ee736-6c1c-4fef-b5af-c0a950371903" />
