### PR TITLE
Id51/内容は同じだが，画像アップロード画面内のUIを調整することにより，スクロールなしでも利用できるようにする

### DIFF
--- a/src/pages/Camera.tsx
+++ b/src/pages/Camera.tsx
@@ -91,7 +91,7 @@ const remainingPhotos = Math.max(0, requiredPhotos - currentPhotos);
         screenshotFormat="image/jpeg"
         videoConstraints={videoConstraints}
       />
-      <button onClick={capture} className="my-4 p-4 text-white font-bold bg-blue-400 rounded-xl shadow-lg">撮影</button>
+      <button onClick={capture} className="my-4 p-4 text-white font-bold bg-blue-400 rounded-xl shadow-lg">撮影する</button>
       <p>残りの必要な撮影枚数: {remainingPhotos} 枚</p>
 
     </>

--- a/src/pages/Camera.tsx
+++ b/src/pages/Camera.tsx
@@ -23,8 +23,8 @@ const WebCamera = ({ entries, setEntries, indexId, setThema, setIndexId_thema, g
 
   // 外カメラ起動に必要な設定
   const videoConstraints = {
-    width: 300,
-    height: 300,
+    width: 200,
+    height: 200,
     facingMode: { exact: "environment" }
   };
 
@@ -91,7 +91,7 @@ const remainingPhotos = Math.max(0, requiredPhotos - currentPhotos);
         screenshotFormat="image/jpeg"
         videoConstraints={videoConstraints}
       />
-      <button onClick={capture} className="my-4 p-4 text-white font-bold bg-blue-400 rounded-xl shadow-lg">撮影する</button>
+      <button onClick={capture} className="my-4 p-4 text-white font-bold bg-blue-400 rounded-xl shadow-lg">撮影</button>
       <p>残りの必要な撮影枚数: {remainingPhotos} 枚</p>
 
     </>

--- a/src/pages/Camera.tsx
+++ b/src/pages/Camera.tsx
@@ -23,8 +23,8 @@ const WebCamera = ({ entries, setEntries, indexId, setThema, setIndexId_thema, g
 
   // 外カメラ起動に必要な設定
   const videoConstraints = {
-    width: 150,
-    height: 150,
+    width: 175,
+    height: 175,
     facingMode: { exact: "environment" }
   };
 

--- a/src/pages/Camera.tsx
+++ b/src/pages/Camera.tsx
@@ -23,8 +23,8 @@ const WebCamera = ({ entries, setEntries, indexId, setThema, setIndexId_thema, g
 
   // 外カメラ起動に必要な設定
   const videoConstraints = {
-    width: 200,
-    height: 200,
+    width: 150,
+    height: 150,
     facingMode: { exact: "environment" }
   };
 

--- a/src/pages/Camera.tsx
+++ b/src/pages/Camera.tsx
@@ -91,7 +91,7 @@ const remainingPhotos = Math.max(0, requiredPhotos - currentPhotos);
         screenshotFormat="image/jpeg"
         videoConstraints={videoConstraints}
       />
-      <button onClick={capture} className="my-4 p-4 text-white font-bold bg-blue-400 rounded-xl shadow-lg">撮影する</button>
+      <button onClick={capture} className="my-4 p-4 text-white font-bold bg-blue-400 rounded-xl shadow-lg">撮影</button>
       <p>残りの必要な撮影枚数: {remainingPhotos} 枚</p>
 
     </>

--- a/src/pages/ImageUpload.tsx
+++ b/src/pages/ImageUpload.tsx
@@ -108,7 +108,7 @@ export default function ImageUpload({ setSceneController, entries, setEntries}: 
 
     <p className="mt-4">お題：「{thema}」</p>
 
-    <button type="button" onClick={ThemaChange} className="my-4 p-4 text-white font-bold bg-green-400 rounded-xl shadow-lg mx-2">お題の変更</button>
+    <button type="button" onClick={ThemaChange} className="my-4 p-4 text-white font-bold bg-green-400 rounded-xl shadow-lg mx-2">お題を変更する</button>
 
     <div
       style={{
@@ -179,7 +179,7 @@ export default function ImageUpload({ setSceneController, entries, setEntries}: 
       onClick={() => setSceneController('Name')}
       className="p-4 text-white font-bold bg-blue-400 rounded-xl shadow-lg m-2"
     >
-      {entries?.[indexId].imgURL.length >= 0 && "← 名前登録"}
+      {entries?.[indexId].imgURL.length >= 0 && "名前登録に戻る"}
     </button>
 
     {indexId < entries?.length - 1 &&
@@ -187,7 +187,7 @@ export default function ImageUpload({ setSceneController, entries, setEntries}: 
       onClick={nextPlayer}
       className="p-4 text-white font-bold bg-blue-400 rounded-xl shadow-lg m-2"
     >
-      次の登録 →
+      次の人の画像登録へ進む
     </button>}
 
     {indexId === entries?.length - 1 && entries?.[indexId].imgURL.length >= 2 && (

--- a/src/pages/ImageUpload.tsx
+++ b/src/pages/ImageUpload.tsx
@@ -106,7 +106,7 @@ export default function ImageUpload({ setSceneController, entries, setEntries}: 
       }}
     ></div>
 
-    <p className="mt-4">お題：「{thema}」　にちなんだ写真を撮ってください．</p>
+    <p className="mt-4">お題：「{thema}」</p>
 
     <button type="button" onClick={ThemaChange} className="my-4 p-4 text-white font-bold bg-green-400 rounded-xl shadow-lg mx-2">お題を変更する</button>
 
@@ -179,7 +179,7 @@ export default function ImageUpload({ setSceneController, entries, setEntries}: 
       onClick={() => setSceneController('Name')}
       className="p-4 text-white font-bold bg-blue-400 rounded-xl shadow-lg m-2"
     >
-      {entries?.[indexId].imgURL.length >= 0 && "プレイヤー登録に戻る"}
+      {entries?.[indexId].imgURL.length >= 0 && "参加者登録に戻る"}
     </button>
 
     {indexId < entries?.length - 1 &&
@@ -187,7 +187,7 @@ export default function ImageUpload({ setSceneController, entries, setEntries}: 
       onClick={nextPlayer}
       className="p-4 text-white font-bold bg-blue-400 rounded-xl shadow-lg m-2"
     >
-      次のプレイヤーの写真を登録
+      次の人の写真を登録する
     </button>}
 
     {indexId === entries?.length - 1 && entries?.[indexId].imgURL.length >= 2 && (
@@ -195,7 +195,7 @@ export default function ImageUpload({ setSceneController, entries, setEntries}: 
         onClick={() => setSceneController('Game')}
         className="p-4 text-white font-bold bg-red-400 rounded-xl shadow-lg m-2"
       >
-        ゲーム開始
+        ゲームスタート
       </button>
       )}
       </div>

--- a/src/pages/ImageUpload.tsx
+++ b/src/pages/ImageUpload.tsx
@@ -108,7 +108,7 @@ export default function ImageUpload({ setSceneController, entries, setEntries}: 
 
     <p className="mt-4">お題：「{thema}」</p>
 
-    <button type="button" onClick={ThemaChange} className="my-4 p-4 text-white font-bold bg-green-400 rounded-xl shadow-lg mx-2">お題を変更する</button>
+    <button type="button" onClick={ThemaChange} className="my-4 p-4 text-white font-bold bg-green-400 rounded-xl shadow-lg mx-2">お題の変更</button>
 
     <div
       style={{
@@ -179,7 +179,7 @@ export default function ImageUpload({ setSceneController, entries, setEntries}: 
       onClick={() => setSceneController('Name')}
       className="p-4 text-white font-bold bg-blue-400 rounded-xl shadow-lg m-2"
     >
-      {entries?.[indexId].imgURL.length >= 0 && "名前登録に戻る"}
+      {entries?.[indexId].imgURL.length >= 0 && "← 名前登録"}
     </button>
 
     {indexId < entries?.length - 1 &&
@@ -187,7 +187,7 @@ export default function ImageUpload({ setSceneController, entries, setEntries}: 
       onClick={nextPlayer}
       className="p-4 text-white font-bold bg-blue-400 rounded-xl shadow-lg m-2"
     >
-      次の人の画像登録へ進む
+      次の登録 →
     </button>}
 
     {indexId === entries?.length - 1 && entries?.[indexId].imgURL.length >= 2 && (

--- a/src/pages/ImageUpload.tsx
+++ b/src/pages/ImageUpload.tsx
@@ -87,9 +87,9 @@ export default function ImageUpload({ setSceneController, entries, setEntries}: 
     }}
     className="mt-4"
     >
-      <ul><span className="font-bold">お題にちなんだポーズ</span>で<span className="text-amber-300 text-2xl font-bold">{entries?.[indexId].name}</span>さんの写真を<span className="text-amber-300 text-2xl font-bold">{indexId === 0 ? entries?.[entries.length - 1].name : entries?.[indexId - 1].name}</span>さんが撮影してね！</ul>
+      <ul><span className="font-bold">お題にちなんだポーズ</span>で<span className="text-amber-300 text-2xl font-bold">{entries?.[indexId].name}</span>さんを<span className="text-amber-300 text-2xl font-bold">{indexId === 0 ? entries?.[entries.length - 1].name : entries?.[indexId - 1].name}</span>さんが撮影してね！</ul>
       {/* <ul>{getRequiredPhotos(entries)}枚以上撮ってください</ul> */}
-      <ul>全員分の写真が集まったらゲームスタート！</ul>
+      <ul>全員分撮影したらゲームスタート！</ul>
       {/* <p className="mt-4">ポーズの例</p> */}
       <div
       className="flex flex-wrap justify-center md:flex-col md:items-start"
@@ -187,7 +187,7 @@ export default function ImageUpload({ setSceneController, entries, setEntries}: 
       onClick={nextPlayer}
       className="p-4 text-white font-bold bg-blue-400 rounded-xl shadow-lg m-2"
     >
-      次の人の写真を登録する
+      次の人を登録する
     </button>}
 
     {indexId === entries?.length - 1 && entries?.[indexId].imgURL.length >= 2 && (

--- a/src/pages/ImageUpload.tsx
+++ b/src/pages/ImageUpload.tsx
@@ -108,7 +108,7 @@ export default function ImageUpload({ setSceneController, entries, setEntries}: 
 
     <p className="mt-4">お題：「{thema}」</p>
 
-    <button type="button" onClick={ThemaChange} className="my-4 p-4 text-white font-bold bg-green-400 rounded-xl shadow-lg mx-2">お題を変更する</button>
+    <button type="button" onClick={ThemaChange} className="my-4 p-4 text-white font-bold bg-green-400 rounded-xl shadow-lg mx-2">お題の変更</button>
 
     <div
       style={{
@@ -149,8 +149,8 @@ export default function ImageUpload({ setSceneController, entries, setEntries}: 
               <Image
                 src={img}
                 alt="Preview"
-                width={150}
-                height={150}
+                width={100}
+                height={100}
                 className="rounded-lg"
               />
               <button
@@ -179,7 +179,7 @@ export default function ImageUpload({ setSceneController, entries, setEntries}: 
       onClick={() => setSceneController('Name')}
       className="p-4 text-white font-bold bg-blue-400 rounded-xl shadow-lg m-2"
     >
-      {entries?.[indexId].imgURL.length >= 0 && "参加者登録に戻る"}
+      {entries?.[indexId].imgURL.length >= 0 && "← 名前登録"}
     </button>
 
     {indexId < entries?.length - 1 &&
@@ -187,7 +187,7 @@ export default function ImageUpload({ setSceneController, entries, setEntries}: 
       onClick={nextPlayer}
       className="p-4 text-white font-bold bg-blue-400 rounded-xl shadow-lg m-2"
     >
-      次の人を登録する
+      次の登録 →
     </button>}
 
     {indexId === entries?.length - 1 && entries?.[indexId].imgURL.length >= 2 && (

--- a/src/pages/InputName.tsx
+++ b/src/pages/InputName.tsx
@@ -48,7 +48,7 @@ export default function InputName({
 
 
       <h1 style={{ fontSize: '24px', fontWeight: 'bold', textAlign: 'center' }}>
-        プレイヤーを登録
+        参加者登録
       </h1>
       <p
         style={{

--- a/src/pages/InputName.tsx
+++ b/src/pages/InputName.tsx
@@ -116,7 +116,7 @@ export default function InputName({
         }}
         className="m-5"
       >
-        画像登録に進む
+        画像登録へ進む
       </button>
     </div>
   );

--- a/src/pages/InputName.tsx
+++ b/src/pages/InputName.tsx
@@ -48,7 +48,7 @@ export default function InputName({
 
 
       <h1 style={{ fontSize: '24px', fontWeight: 'bold', textAlign: 'center' }}>
-        参加者登録
+        名前登録
       </h1>
       <p
         style={{

--- a/src/pages/InputName.tsx
+++ b/src/pages/InputName.tsx
@@ -116,7 +116,7 @@ export default function InputName({
         }}
         className="m-5"
       >
-        画像登録へ進む
+        画像登録に進む
       </button>
     </div>
   );


### PR DESCRIPTION
やったこと
- お題の部分・カメラ部分・画像プレビュー部分がスクロールせずに1ページに収まるようにした
     - 撮影画面内の画像サイズを縮小した
     - 「お題の変更」ボタンの上に表示する文の表現を変更した
     - 撮影画面内の各ボタン内の表現を変更した
- 「プレイヤーを登録」を「名前登録」に変更した

変更前の画面
<img width="211" alt="スクリーンショット 2025-03-21 12 46 58" src="https://github.com/user-attachments/assets/4253b114-a384-41b8-adc3-ebc155f943ca" />
<img width="430" alt="スクリーンショット 2025-03-21 12 47 21" src="https://github.com/user-attachments/assets/8c73b94b-388c-4532-828e-65c01dba3f03" />
<img width="429" alt="スクリーンショット 2025-03-21 12 47 38" src="https://github.com/user-attachments/assets/00a33bff-39e5-4572-9cf9-e3644dd1a207" />

変更後の画面
<img width="214" alt="スクリーンショット 2025-03-21 12 42 34" src="https://github.com/user-attachments/assets/2546aa76-0c69-42e6-994d-d04a4d862136" />
<img width="389" alt="スクリーンショット 2025-03-21 13 18 28" src="https://github.com/user-attachments/assets/e2bf47d0-2505-48f4-882e-aac323cfc725" />
<img width="392" alt="スクリーンショット 2025-03-21 13 18 43" src="https://github.com/user-attachments/assets/c4c02a0e-b065-46a3-a399-4a4cc350dc85" />
