### PR TITLE
撮影画面内の「←名前登録」ボタンを「名前登録に戻る」ボタンに変更

### DIFF
--- a/src/pages/ImageUpload.tsx
+++ b/src/pages/ImageUpload.tsx
@@ -179,7 +179,7 @@ export default function ImageUpload({ setSceneController, entries, setEntries}: 
       onClick={() => setSceneController('Name')}
       className="p-4 text-white font-bold bg-blue-400 rounded-xl shadow-lg m-2"
     >
-      {entries?.[indexId].imgURL.length >= 0 && "← 名前登録"}
+      {entries?.[indexId].imgURL.length >= 0 && "名前登録に戻る"}
     </button>
 
     {indexId < entries?.length - 1 &&


### PR DESCRIPTION
・やったこと
やーさんの指摘を基に，「←名前登録」ボタンを「名前登録に戻る」ボタンに変更

・変更前の画像
<img width="487" alt="スクリーンショット 2025-03-21 21 00 42" src="https://github.com/user-attachments/assets/a94f0881-c35e-4dd1-aec1-93f233a66b01" />
<img width="485" alt="スクリーンショット 2025-03-21 21 00 56" src="https://github.com/user-attachments/assets/5157091f-09f7-4269-85c6-18037b24ebc8" />

・変更後の画像
<img width="492" alt="スクリーンショット 2025-03-21 20 59 44" src="https://github.com/user-attachments/assets/2f809e22-af37-42aa-89c3-84ef4c41187b" />
<img width="489" alt="スクリーンショット 2025-03-21 21 00 05" src="https://github.com/user-attachments/assets/d2df0446-3b4e-4745-896e-9155b6c73065" />
